### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Dan Hasting <maintainer@hasting.email>
 Rules-Requires-Root: no
 Build-Depends: debhelper-compat (= 13), qtbase5-dev, libquazip5-dev, libqt5sql5-sqlite
-Standards-Version: 4.5.0
+Standards-Version: 4.6.1
 Homepage: https://github.com/dh4/cen64-qt
 Vcs-Git: https://github.com/dh4/cen64-qt-debian.git
 Vcs-Browser: https://github.com/dh4/cen64-qt-debian/

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Dan Hasting <maintainer@hasting.email>
 Rules-Requires-Root: no
 Build-Depends: debhelper-compat (= 13), qtbase5-dev, libquazip5-dev, libqt5sql5-sqlite
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Homepage: https://github.com/dh4/cen64-qt
 Vcs-Git: https://github.com/dh4/cen64-qt-debian.git
 Vcs-Browser: https://github.com/dh4/cen64-qt-debian/

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: otherosfs
 Priority: optional
 Maintainer: Dan Hasting <maintainer@hasting.email>
 Rules-Requires-Root: no
-Build-Depends: debhelper-compat (= 12), qtbase5-dev, libquazip5-dev, libqt5sql5-sqlite
+Build-Depends: debhelper-compat (= 13), qtbase5-dev, libquazip5-dev, libqt5sql5-sqlite
 Standards-Version: 4.5.0
 Homepage: https://github.com/dh4/cen64-qt
 Vcs-Git: https://github.com/dh4/cen64-qt-debian.git

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
-version=3
+version=4
 https://github.com/dh4/cen64-qt/tags .*/v?(\d.*)\.(?:tgz|tbz2|tar\.(?:gz|bz2|xz))


### PR DESCRIPTION
Fix some issues reported by lintian

* Update watch file format version to 4. ([older-debian-watch-file-standard](https://lintian.debian.org/tags/older-debian-watch-file-standard))
* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/9c/960523155b4cb9e98c802b3ae6069ec8438287.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/62/94d04f2c6f71ca2fdcd918155fccf217507225.debug

No differences were encountered between the control files of package \*\*cen64-qt\*\*
### Control files of package cen64-qt-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-6294d04f2c6f71ca2fdcd918155fccf217507225-] {+9c960523155b4cb9e98c802b3ae6069ec8438287+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a5bbaa06-041c-4af1-b892-c3ca85d88666/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a5bbaa06-041c-4af1-b892-c3ca85d88666/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/cen64-qt/a5bbaa06-041c-4af1-b892-c3ca85d88666.